### PR TITLE
Delete duplicated sentence

### DIFF
--- a/_episodes/03-qc-of-sequencing-results.md
+++ b/_episodes/03-qc-of-sequencing-results.md
@@ -341,9 +341,6 @@ For each of the samples there are two files. a .html and a .zip
 If we were working on our local computer, outside of the container, we'd be able to display each of these
 HTML files as a webpage:
 
-If we were working on our local computers, we'd be able to display each of these
-HTML files as a webpage:
-
 ~~~
 $ cd fastqc/
 $ open Arabidopsis_sample1_fastqc.html


### PR DESCRIPTION
Under the "3.2. Viewing the FastQC results" it explains twice that in our local computers we could see the HTML files as webpages